### PR TITLE
Package name is community but python-louvain on pypi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ismember
 sklearn
 funcsigs
 statsmodels
-community
+python-louvain
 packaging
 wget
 df2onehot

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
                        'sklearn',
                        'funcsigs',
                        'statsmodels',
-                       'community',
+                       'python-louvain',
                        'packaging',
                        'wget',
                        'df2onehot',


### PR DESCRIPTION
Hi, I've noticed that there is a "community" package [1] in the requirements.txt and setup.py, but I believe that the intention was to require the python-louvain package [2][3].

[1] https://pypi.org/project/community/
[2] https://pypi.org/project/python-louvain/
[3] https://github.com/taynaud/python-louvain
