### PR TITLE
Call plt.show() when 'visible'=True

### DIFF
--- a/bnlearn/bnlearn.py
+++ b/bnlearn/bnlearn.py
@@ -1107,7 +1107,8 @@ def _plot_static(model, params_static, nodelist, node_colors, node_sizes, G, pos
     # Making figure nice
     # fig = plt.gca()
     # fig.set_axis_off()
-    fig.set_visible(visible)
+    if visible:
+        plt.show()
     # Return
     return fig
 


### PR DESCRIPTION
Plot stopped working for me since version 0.7.9 and I think it is because the plt.show() was not there anymore. 