### PR TITLE
fix 2 minor bugs

### DIFF
--- a/bnlearn/bnlearn.py
+++ b/bnlearn/bnlearn.py
@@ -1549,11 +1549,12 @@ def predict(model, df, variables, to_df=True, method='max', verbose=3):
 
 # %%
 def _get_prob(query, method='max'):
-    # Setup all combinations
-    allcomb = np.array(list(itertools.product([0, 1], repeat=len(query.variables))))
-    # Get highest P-value and gather data
-    Pq = query.values.flatten()
     if method=='max':
+        # Setup all combinations
+        possible_values = query.state_names.values()
+        allcomb = np.array(list(itertools.product(*possible_values)))
+        # Get highest P-value and gather data
+        Pq = query.values.flatten()
         idx = np.argmax(Pq)
         comb = allcomb[idx]
         p = Pq[idx]

--- a/bnlearn/discretize/learn_discrete_bayes_net.py
+++ b/bnlearn/discretize/learn_discrete_bayes_net.py
@@ -167,9 +167,11 @@ def prior_of_intval(continuous: pd.Series, lam: int) -> np.ndarray:
     N = len(continuous)
     d_1_N = continuous.iloc[N - 1] - continuous.iloc[0]
     prior = np.zeros(N, dtype="float64")
+    # Small positive number to avoid zero 
+    epsilon = 1e-10  
     for i in range(N - 1):
         d_i = continuous.iloc[i + 1] - continuous.iloc[i]
-        prior[i] = 1 - math.exp(-lam * d_i / d_1_N)
+        prior[i] = 1 - math.exp(-lam * d_i / d_1_N) + epsilon
     prior[N - 1] = 1
 
     return prior


### PR DESCRIPTION
1. For bnlearn.py, fix bug in predict when variable has more than one state
2. For learn_discrete_bayes_net.py, due to the limited precision of floating-point calculations in computers, a zero value may occur at line 172. This can lead to a ValueError: math domain error when calculating math.log at line 322 in subsequent computations. After researching for a solution, I have added a very small value (1e-10) at this point to perform smoothing. Now the program runs without any issues. If there are any issues with this approach, please let me know, and I will try to make modifications.