### PR TITLE
Fix the bug in the discretize method caused by the misalignment of column order 

### DIFF
--- a/bnlearn/discretize/discretize.py
+++ b/bnlearn/discretize/discretize.py
@@ -46,6 +46,8 @@ def discretize(
         verbose=verbose,
     )
 
+    continuous_columns = sorted(continuous_columns, key=lambda x: data.columns.get_loc(x))
+    
     # Extend the breaks to the left with 1% to deal with (open,closed] intervals
     for i, col in enumerate(continuous_columns):
         breaks = continuous_edges[i]


### PR DESCRIPTION
Bug description: The elements in continuous_columns passed into the discretize method are not necessarily strictly increasing according to the column indices in the data. However, the discretize_all method returns continuous_edges assuming this order. This leads to a consistent error triggering at line 59, pd.Categorical.from_codes, with the message: ValueError: codes need to be between -1 and len(categories)-1.

To reproduce the issue, in the example provided in the "Advanced discretizing continuous data" section, replace `continuous_columns = ["mpg", "displacement", "horsepower", "weight", "acceleration"]` with `continuous_columns = ["mpg", "displacement", "horsepower", "acceleration", "weight"]`, or change the order in any way that differs from the order in the df. This will consistently trigger the error.

To fix the issue, sorting the continuous_columns in the correct order.