### PR TITLE
fix: add validate=['builtins'] to pypickle.load to resolve Unpickling…

### DIFF
--- a/bnlearn/bnlearn.py
+++ b/bnlearn/bnlearn.py
@@ -1975,7 +1975,7 @@ def load(filepath='bnlearn_model.pkl', verbose=3):
         filepath = filepath + '.pkl'
     filepath = str(Path(filepath).absolute())
     # Load
-    model = pypickle.load(filepath, verbose=verbose)
+    model = pypickle.load(filepath, verbose=verbose, validate=['builtins'])
     # Store in self.
     if model is not None:
         return model


### PR DESCRIPTION
fix: resolve UnpicklingError by adding validate=['builtins'] in bnlearn.load()

Recent pypickle versions added security checks that block unvalidated builtins by default.
This change updates the load function to explicitly allow 'builtins', fixing loading issues with existing bnlearn pickle files.

`[pypickle]> WARNING use the standardized verbose status. The status [1-6] will be deprecated in future versions.
[19-05-2025 15:22:29] [pypickle.pypickle] [INFO] Loading Pickle file: <file.pkl>
[19-05-2025 15:22:29] [pypickle.pypickle] [ERROR] UnpicklingError: [BLOCKED] Module 'builtins' is considered risky. Use validate=['builtins'] to allow.
[bnlearn] >WARNING: Could not load data from [<file.pkl>]
None
Traceback (most recent call last):
  File "/Users/JyotiSrivastava/Documents/causal-llm-bfs/run.py", line 27, in <module>
    adj_mat = bn_model['adjmat'].to_numpy().astype(int)
TypeError: 'NoneType' object is not subscriptable`

Closes #112
