### PR TITLE
Add conditional sampling: bn.sampling(..., evidence={...}) (closes #67, #91)

### DIFF
--- a/bnlearn/bnlearn.py
+++ b/bnlearn/bnlearn.py
@@ -640,8 +640,8 @@ def adjmat2dict(adjmat):
 
 
 # %%
-def sampling(DAG, n=1000, methodtype='bayes', verbose=0):
-    return bn_sampling(DAG, n=n, methodtype=methodtype, verbose=verbose)
+def sampling(DAG, n=1000, methodtype='bayes', evidence=None, verbose=0):
+    return bn_sampling(DAG, n=n, methodtype=methodtype, evidence=evidence, verbose=verbose)
 
 
 # %% Convert BIF model to bayesian model

--- a/bnlearn/sampling.py
+++ b/bnlearn/sampling.py
@@ -123,11 +123,25 @@ def sampling(DAG, n=1000, methodtype='bayes', evidence=None, verbose=0):
 
 # %% Convert an evidence dict into pgmpy State tuples
 def _evidence_as_states(evidence, model):
-    """Convert an evidence dict {variable: state} into a list of pgmpy State tuples."""
+    """Convert an evidence dict {variable: state} into a list of pgmpy State tuples.
+
+    Each variable is checked against the model, and each requested state against
+    that variable's state space. Impossible evidence (an unknown variable or a
+    state that the variable can never take) therefore fails fast with a clear
+    message instead of hanging the rejection sampler, which would otherwise loop
+    forever waiting to accept a sample that can never occur.
+    """
     if not isinstance(evidence, dict):
         raise TypeError('[bnlearn] >evidence must be a dict of {variable: state}, e.g. {"Rain": 1}.')
     nodes = set(model.nodes())
     unknown = [var for var in evidence if var not in nodes]
     if len(unknown)>0:
         raise ValueError('[bnlearn] >evidence variable(s) %s are not in the model (case sensitive!). Available nodes: %s' %(unknown, sorted(nodes)))
-    return [State(var, state) for var, state in evidence.items()]
+
+    states = []
+    for var, state in evidence.items():
+        valid_states = model.get_cpds(var).state_names[var]
+        if state not in valid_states:
+            raise ValueError('[bnlearn] >evidence state [%s=%s] is not a valid state for variable [%s]. Valid states: %s' %(var, state, var, valid_states))
+        states.append(State(var, state))
+    return states

--- a/bnlearn/sampling.py
+++ b/bnlearn/sampling.py
@@ -7,6 +7,7 @@
 # ------------------------------------
 
 from pgmpy.sampling import BayesianModelSampling, GibbsSampling
+from pgmpy.factors.discrete import State
 import pandas as pd
 # import logging
 # logging.getLogger("pgmpy").setLevel(logging.ERROR)
@@ -29,7 +30,7 @@ def _patched_from_records(cls, data, *args, **kwargs):
 pd.DataFrame.from_records = _patched_from_records
 
 # %% Sampling from model
-def sampling(DAG, n=1000, methodtype='bayes', verbose=0):
+def sampling(DAG, n=1000, methodtype='bayes', evidence=None, verbose=0):
     """Generate synthetic data using the joint distribution of the network.
 
     Parameters
@@ -37,10 +38,19 @@ def sampling(DAG, n=1000, methodtype='bayes', verbose=0):
     DAG : dict
         Contains model and the adjmat of the DAG.
     methodtype : str (default: 'bayes')
-        * 'bayes': Forward sampling using Bayesian.
-        * 'gibbs' : Gibbs sampling.
+        * 'bayes': Forward sampling using Bayesian. When ``evidence`` is
+          provided, rejection sampling is used to draw samples that are
+          consistent with the evidence.
+        * 'gibbs' : Gibbs sampling (does not support ``evidence``).
     n : int, optional
         Number of samples to generate. The default is 1000.
+    evidence : dict, optional
+        Condition the samples on the given evidence, e.g. ``{'Rain': 1,
+        'Cloudy': 0}``. Keys must be variable names in the model (case
+        sensitive) and values the observed state. Only supported for
+        ``methodtype='bayes'``, where it switches to rejection sampling so
+        every returned sample is consistent with the evidence. The default is
+        None (unconditional sampling).
     verbose : int, optional
         Print progress to screen. The default is 3.
         0: None, 1: ERROR, 2: WARN, 3: INFO (default), 4: DEBUG, 5: TRACE
@@ -76,6 +86,11 @@ def sampling(DAG, n=1000, methodtype='bayes', verbose=0):
     >>> model = bn.parameter_learning.fit(DAG, df, verbose=3, methodtype='bayes')
     >>> # Sampling using gibbs
     >>> df = bn.sampling(model, n=100, methodtype='gibbs', verbose=0)
+    >>>
+    >>> # Example 3: Conditional sampling
+    >>>
+    >>> # Draw samples in which it is raining and not cloudy
+    >>> df = bn.sampling(model, n=100, evidence={'Rain': 1, 'Cloudy': 0})
 
     """
     if n<=0: raise ValueError('Number of samples (n) must be 1 or larger!')
@@ -84,18 +99,35 @@ def sampling(DAG, n=1000, methodtype='bayes', verbose=0):
 
     if len(DAG['model'].get_cpds())==0:
         raise Exception('[bnlearn] >Error! This is a Bayesian DAG containing only edges, and no CPDs. Tip: you need to specify or learn the CPDs. Try: DAG=bn.parameter_learning.fit(DAG, df). At this point you can make a plot with: bn.plot(DAG).')
-        return
 
     if methodtype=='bayes':
-        if verbose>=3: print('[bnlearn] >Bayesian forward sampling for %.0d samples..' %(n))
-        # Bayesian Forward sampling and make dataframe
         infer_model = BayesianModelSampling(DAG['model'])
-        df = infer_model.forward_sample(size=n, seed=None, show_progress=(True if verbose>=3 else False))
+        if evidence is None:
+            if verbose>=3: print('[bnlearn] >Bayesian forward sampling for %.0d samples..' %(n))
+            df = infer_model.forward_sample(size=n, seed=None, show_progress=(verbose>=3))
+        else:
+            states = _evidence_as_states(evidence, DAG['model'])
+            if verbose>=3: print('[bnlearn] >Bayesian rejection sampling for %.0d samples conditioned on %.0d evidence variable(s)..' %(n, len(states)))
+            df = infer_model.rejection_sample(evidence=states, size=n, seed=None, show_progress=(verbose>=3))
     elif methodtype=='gibbs':
+        if evidence is not None:
+            raise ValueError("[bnlearn] >Gibbs sampling does not support conditioning on evidence. Use methodtype='bayes' together with evidence=... for conditional (rejection) sampling.")
         if verbose>=3: print('[bnlearn] >Gibbs sampling for %.0d samples..' %(n))
         # Gibbs sampling
         gibbs = GibbsSampling(DAG['model'])
         df = gibbs.sample(size=n, seed=None)
     else:
-        if verbose>=3: print('[bnlearn] >Methodtype [%s] unknown' %(methodtype))
+        raise ValueError('[bnlearn] >Sampling methodtype [%s] is unknown. Use "bayes" or "gibbs".' %(methodtype))
     return df
+
+
+# %% Convert an evidence dict into pgmpy State tuples
+def _evidence_as_states(evidence, model):
+    """Convert an evidence dict {variable: state} into a list of pgmpy State tuples."""
+    if not isinstance(evidence, dict):
+        raise TypeError('[bnlearn] >evidence must be a dict of {variable: state}, e.g. {"Rain": 1}.')
+    nodes = set(model.nodes())
+    unknown = [var for var in evidence if var not in nodes]
+    if len(unknown)>0:
+        raise ValueError('[bnlearn] >evidence variable(s) %s are not in the model (case sensitive!). Available nodes: %s' %(unknown, sorted(nodes)))
+    return [State(var, state) for var, state in evidence.items()]

--- a/bnlearn/tests/test_bnlearn.py
+++ b/bnlearn/tests/test_bnlearn.py
@@ -177,6 +177,11 @@ def test_sampling_evidence_errors():
     # Evidence variable not in the model
     with pytest.raises(ValueError):
         bn.sampling(model, n=10, evidence={'DoesNotExist': 1})
+    # Evidence state outside the variable's state space must fail fast rather than
+    # hang the rejection sampler (which would loop forever waiting to accept a
+    # sample that can never occur).
+    with pytest.raises(ValueError):
+        bn.sampling(model, n=10, evidence={'Rain': 99})
     # Gibbs does not support evidence
     with pytest.raises(ValueError):
         bn.sampling(model, n=10, methodtype='gibbs', evidence={'Rain': 1})

--- a/bnlearn/tests/test_bnlearn.py
+++ b/bnlearn/tests/test_bnlearn.py
@@ -162,6 +162,29 @@ def test_sampling_gibbs(sprinkler_dag):
     assert df.shape == (n, 4)
 
 
+def test_sampling_conditional():
+    # Conditional (rejection) sampling: every returned sample must satisfy the evidence.
+    n = np.random.randint(10, 500)
+    model = bn.import_DAG('sprinkler')
+    df = bn.sampling(model, n=n, evidence={'Rain': 1, 'Cloudy': 0})
+    assert df.shape == (n, 4)
+    assert (df['Rain'] == 1).all()
+    assert (df['Cloudy'] == 0).all()
+
+
+def test_sampling_evidence_errors():
+    model = bn.import_DAG('sprinkler')
+    # Evidence variable not in the model
+    with pytest.raises(ValueError):
+        bn.sampling(model, n=10, evidence={'DoesNotExist': 1})
+    # Gibbs does not support evidence
+    with pytest.raises(ValueError):
+        bn.sampling(model, n=10, methodtype='gibbs', evidence={'Rain': 1})
+    # Unknown methodtype
+    with pytest.raises(ValueError):
+        bn.sampling(model, n=10, methodtype='does_not_exist')
+
+
 # def test_to_undirected():
 #     # TEST 1:
 #     randdata = ['sprinkler', 'alarm', 'andes', 'asia', 'sachs']


### PR DESCRIPTION
## What

Adds an `evidence` argument to `bn.sampling()` so users can draw samples **conditioned on known variables** — the feature requested in #67 (sampling conditioned on evidence) and #91 (conditioning Gibbs sampling on evidence).

```python
import bnlearn as bn
model = bn.import_DAG('sprinkler')

# every returned row has Rain=1 and Cloudy=0
df = bn.sampling(model, n=100, evidence={'Rain': 1, 'Cloudy': 0})
```

This directly answers the use case in #67 (e.g. drawing more of an under-represented subgroup to balance classes).

## How

- `evidence` is a `{variable: state}` dict, default `None` (unconditional — fully backward compatible).
- For `methodtype='bayes'` with evidence, it uses pgmpy's **rejection sampling**, so all `n` returned rows are consistent with the evidence.
- **#91:** Gibbs sampling cannot condition on evidence, so `methodtype='gibbs'` + `evidence=...` raises a clear error pointing at the bayes path — the honest answer to that issue.
- Evidence is validated up front: unknown variable names, and — importantly — **states outside a variable's state space** raise a clear `ValueError` listing the valid states. Without this, impossible evidence (e.g. `{'Rain': 99}`) would make pgmpy's rejection sampler loop forever waiting to accept a sample that can never occur.
- Minor robustness bonus: an unknown `methodtype` now raises `ValueError` instead of silently returning an undefined local.

## Tests

- `test_sampling_conditional` — asserts every sampled row satisfies the evidence.
- `test_sampling_evidence_errors` — unknown evidence variable, out-of-range evidence state (fast-fail, no hang), gibbs+evidence, and unknown methodtype.

Full `bnlearn/tests/test_bnlearn.py` passes (23 passed) on Python 3.12.

## Notes

Reviewed via automated review bots on my fork first; a P1 (the impossible-evidence hang) was caught there and fixed before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)