### PR TITLE
Fix pgmpy version-check message to match the pinned 0.1.25

### DIFF
--- a/bnlearn/__init__.py
+++ b/bnlearn/__init__.py
@@ -91,7 +91,7 @@ __version__ = '0.13.0'
 import pgmpy
 # Check version pgmpy
 if version.parse(pgmpy.__version__) < version.parse("0.1.18"):
-    raise ImportError('[bnlearn] >Error: This release requires pgmpy to be version == 0.1.26. Try to: <pip install -U pgmpy==0.1.26>')
+    raise ImportError('[bnlearn] >Error: This release requires pgmpy to be version == 0.1.25. Try to: <pip install -U pgmpy==0.1.25>')
 
 # Version check
 import matplotlib


### PR DESCRIPTION
The runtime pgmpy version check in `bnlearn/__init__.py` tells users to install `pgmpy==0.1.26`, but bnlearn pins **`pgmpy==0.1.25`** (both `pyproject.toml` and `requirements.txt`). 0.1.26+ is precisely the range the pin exists to avoid, so following the old message would break the install. This one-line change points the message (and its suggested `pip install`) at the correct `0.1.25`.

Message-only; the `< 0.1.18` threshold and all logic are unchanged. `import bnlearn` verified, no `0.1.26` reference remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)