### PR TITLE
Feature/conditional sampling zero probability

### DIFF
--- a/bnlearn/sampling.py
+++ b/bnlearn/sampling.py
@@ -8,6 +8,7 @@
 
 from pgmpy.sampling import BayesianModelSampling, GibbsSampling
 from pgmpy.factors.discrete import State
+from pgmpy.inference import VariableElimination
 import pandas as pd
 # import logging
 # logging.getLogger("pgmpy").setLevel(logging.ERROR)
@@ -107,6 +108,8 @@ def sampling(DAG, n=1000, methodtype='bayes', evidence=None, verbose=0):
             df = infer_model.forward_sample(size=n, seed=None, show_progress=(verbose>=3))
         else:
             states = _evidence_as_states(evidence, DAG['model'])
+            if _evidence_probability(evidence, DAG['model']) <= 0:
+                raise ValueError('[bnlearn] >evidence %s has zero probability under the model. Rejection sampling cannot produce matching samples.' %(evidence))
             if verbose>=3: print('[bnlearn] >Bayesian rejection sampling for %.0d samples conditioned on %.0d evidence variable(s)..' %(n, len(states)))
             df = infer_model.rejection_sample(evidence=states, size=n, seed=None, show_progress=(verbose>=3))
     elif methodtype=='gibbs':
@@ -145,3 +148,11 @@ def _evidence_as_states(evidence, model):
             raise ValueError('[bnlearn] >evidence state [%s=%s] is not a valid state for variable [%s]. Valid states: %s' %(var, state, var, valid_states))
         states.append(State(var, state))
     return states
+
+def _evidence_probability(evidence, model):
+    if len(evidence)==0:
+        return 1
+
+    distribution = VariableElimination(model).query(variables=list(evidence), show_progress=False)
+    state_numbers = tuple(distribution.get_state_no(var, evidence[var]) for var in distribution.variables)
+    return distribution.values[state_numbers]

--- a/bnlearn/sampling.py
+++ b/bnlearn/sampling.py
@@ -108,7 +108,7 @@ def sampling(DAG, n=1000, methodtype='bayes', evidence=None, verbose=0):
             df = infer_model.forward_sample(size=n, seed=None, show_progress=(verbose>=3))
         else:
             states = _evidence_as_states(evidence, DAG['model'])
-            if _evidence_probability(evidence, DAG['model']) <= 0:
+            if not _evidence_is_possible(evidence, DAG['model']):
                 raise ValueError('[bnlearn] >evidence %s has zero probability under the model. Rejection sampling cannot produce matching samples.' %(evidence))
             if verbose>=3: print('[bnlearn] >Bayesian rejection sampling for %.0d samples conditioned on %.0d evidence variable(s)..' %(n, len(states)))
             df = infer_model.rejection_sample(evidence=states, size=n, seed=None, show_progress=(verbose>=3))
@@ -149,18 +149,20 @@ def _evidence_as_states(evidence, model):
         states.append(State(var, state))
     return states
 
-def _evidence_probability(evidence, model):
-    if len(evidence)==0:
-        return 1.0
+
+def _evidence_is_possible(evidence, model):
+    """Return whether the joint evidence has non-zero probability."""
+    if len(evidence) == 0:
+        return True
 
     infer_model = VariableElimination(model)
-    probability = 1.0
     observed = {}
     for var, state in evidence.items():
         distribution = infer_model.query(variables=[var], evidence=observed, show_progress=False)
         state_number = distribution.get_state_no(var, state)
-        probability *= distribution.values[state_number]
-        if probability==0:
-            return 0.0
+        # Check each conditional factor directly. Multiplying the factors can
+        # underflow and incorrectly classify very unlikely evidence as impossible.
+        if distribution.values[state_number] == 0:
+            return False
         observed[var] = state
-    return probability
+    return True

--- a/bnlearn/sampling.py
+++ b/bnlearn/sampling.py
@@ -151,8 +151,16 @@ def _evidence_as_states(evidence, model):
 
 def _evidence_probability(evidence, model):
     if len(evidence)==0:
-        return 1
+        return 1.0
 
-    distribution = VariableElimination(model).query(variables=list(evidence), show_progress=False)
-    state_numbers = tuple(distribution.get_state_no(var, evidence[var]) for var in distribution.variables)
-    return distribution.values[state_numbers]
+    infer_model = VariableElimination(model)
+    probability = 1.0
+    observed = {}
+    for var, state in evidence.items():
+        distribution = infer_model.query(variables=[var], evidence=observed, show_progress=False)
+        state_number = distribution.get_state_no(var, state)
+        probability *= distribution.values[state_number]
+        if probability==0:
+            return 0.0
+        observed[var] = state
+    return probability

--- a/bnlearn/tests/test_bnlearn.py
+++ b/bnlearn/tests/test_bnlearn.py
@@ -205,6 +205,33 @@ def test_sampling_rejects_jointly_impossible_evidence(monkeypatch):
         bn.sampling(model, n=1, evidence={'A': 0, 'B': 1})
 
 
+def test_sampling_evidence_possibility_check_does_not_underflow(monkeypatch):
+    import importlib
+
+    sampling_module = importlib.import_module('bnlearn.sampling')
+
+    class TinyConditionalDistribution:
+        values = np.array([1e-100])
+
+        @staticmethod
+        def get_state_no(var, state):
+            return 0
+
+    class TinyConditionalInference:
+        def __init__(self, model):
+            pass
+
+        def query(self, variables, evidence, show_progress):
+            return TinyConditionalDistribution()
+
+    monkeypatch.setattr(sampling_module, 'VariableElimination', TinyConditionalInference)
+
+    # The product of four non-zero 1e-100 factors underflows to zero, but the
+    # evidence is still possible and must not be rejected as impossible.
+    evidence = {'A': 1, 'B': 1, 'C': 1, 'D': 1}
+    assert sampling_module._evidence_is_possible(evidence, model=None)
+
+
 # def test_to_undirected():
 #     # TEST 1:
 #     randdata = ['sprinkler', 'alarm', 'andes', 'asia', 'sachs']

--- a/bnlearn/tests/test_bnlearn.py
+++ b/bnlearn/tests/test_bnlearn.py
@@ -4,6 +4,7 @@
 import pytest
 import bnlearn as bn
 from pgmpy.factors.discrete import TabularCPD
+from pgmpy.sampling import BayesianModelSampling
 import numpy as np
 import pandas as pd
 import matplotlib
@@ -188,6 +189,20 @@ def test_sampling_evidence_errors():
     # Unknown methodtype
     with pytest.raises(ValueError):
         bn.sampling(model, n=10, methodtype='does_not_exist')
+
+
+def test_sampling_rejects_jointly_impossible_evidence(monkeypatch):
+    cpd_a = TabularCPD(variable='A', variable_card=2, values=[[0.5], [0.5]])
+    cpd_b = TabularCPD(variable='B', variable_card=2, values=[[1, 0], [0, 1]],
+                       evidence=['A'], evidence_card=[2])
+    model = bn.make_DAG([('A', 'B')], CPD=[cpd_a, cpd_b], checkmodel=True)
+
+    def fail_if_called(*args, **kwargs):
+        pytest.fail('rejection_sample must not run for zero-probability evidence')
+
+    monkeypatch.setattr(BayesianModelSampling, 'rejection_sample', fail_if_called)
+    with pytest.raises(ValueError, match='zero probability'):
+        bn.sampling(model, n=1, evidence={'A': 0, 'B': 1})
 
 
 # def test_to_undirected():


### PR DESCRIPTION
The previous conditional-sampling update could pass impossible evidence combinations to rejection sampling, causing an infinite loop. This change detects them up front. Rare but possible combinations may still take a long time to sample.