### PR TITLE
Make the test environment reproducible: install from pyproject, declare a dev extra

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest
+          pip install -e ".[dev]"
 
       - name: Run tests
         run: pytest -v

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ pip install -e ".[dev]"
 pytest
 ```
 With uv, use `uv sync --extra dev` followed by `uv run pytest`.
+
 ##### Load library
 ```python
 # Import library

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Because probabilistic graphical models can be difficult to use, ``Bnlearn`` cont
 ---
 ### Installation
 
+Python 3.10 or newer is required.
+
 ##### Install bnlearn from PyPI
 ```bash
 pip install bnlearn
@@ -104,6 +106,12 @@ pip install bnlearn
 ```bash
 pip install git+https://github.com/erdogant/bnlearn
 ```
+##### Run the tests from a source checkout
+```bash
+pip install -e ".[dev]"
+pytest
+```
+With uv, use `uv sync --extra dev` followed by `uv run pytest`.
 ##### Load library
 ```python
 # Import library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{ name = "Erdogan Taskesen", email = "erdogant@gmail.com" },]
 description = "bnlearn is a Python package for Causal Discovery by learning the graphical structure of Bayesian networks, parameter learning, inference and sampling methods."
 readme = "README.md"
-requires-python = ">=3"
+requires-python = ">=3.10"
 license = "MIT"
 keywords = ["Python", "causal discovery", "causal learning"]
 classifiers = [
@@ -39,6 +39,12 @@ dependencies = [
     "datazets>=1.1.2",
     "setgraphviz>=1.0.3",
     "lingam",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
 ]
 
 [project.urls]


### PR DESCRIPTION
Small packaging/CI cleanup so that `pyproject.toml` is the single source of truth for a test install:

- **CI** installs `pip install -e ".[dev]"` instead of `requirements.txt` + a separate `pip install pytest`.
- **New `dev` extra** declaring `pytest` and `pytest-cov`.
- **`requires-python`**: `">=3"` → `">=3.10"`. This just makes the declared floor match reality — the CI matrix already starts at 3.10, and `">=3"` is too loose for resolvers (uv, for one, can't lock against it). Flagging it explicitly since it's a visible metadata change.
- **README**: note the 3.10 floor and add a short "run the tests from a source checkout" section (pip and uv variants).

One follow-up worth considering (not in this PR): with CI no longer reading it, `requirements.txt` only duplicates `pyproject.toml` and can silently drift — it could be slimmed or removed. Your call.

Verified locally on top of current `master`: the `.[dev]` install resolves cleanly and the full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMjFQWcJ8n6jieKjAALAcR